### PR TITLE
Allow anyone to use the web client

### DIFF
--- a/assets/js/play/client.js
+++ b/assets/js/play/client.js
@@ -10,6 +10,7 @@ import Keys from './keys';
 
 let body = document.getElementById("body");
 let userToken = body.getAttribute("data-user-token");
+let sessionToken = body.getAttribute("data-session-token");
 
 const keys = new Keys();
 
@@ -30,7 +31,7 @@ class SocketProvider extends React.Component {
       gmcp: {},
     }
 
-    this.socket = new ClientSocket(this, this.props.game, userToken);
+    this.socket = new ClientSocket(this, this.props.game, userToken, sessionToken);
     this.socket.join();
   }
 

--- a/assets/js/play/socket.js
+++ b/assets/js/play/socket.js
@@ -3,14 +3,15 @@ import Sizzle from "sizzle"
 import _ from "underscore"
 
 class ClientSocket {
-  constructor(client, game, userToken) {
+  constructor(client, game, userToken, sessionToken) {
     this.client = client;
     this.game = game;
     this.userToken = userToken;
+    this.sessionToken = sessionToken;
   }
 
   join() {
-    this.socket = new Socket("/websocket", {params: {token: this.userToken}});
+    this.socket = new Socket("/websocket", {params: {token: this.userToken, session: this.sessionToken}});
     this.socket.connect();
     this.connect();
   }

--- a/lib/grapevine/games/game.ex
+++ b/lib/grapevine/games/game.ex
@@ -25,6 +25,7 @@ defmodule Grapevine.Games.Game do
     field(:display, :boolean, default: true)
     field(:allow_character_registration, :boolean, default: true)
     field(:enable_web_client, :boolean, default: false)
+    field(:allow_anonymous_client, :boolean, default: false)
 
     field(:last_seen_at, :utc_datetime)
     field(:mssp_last_seen_at, :utc_datetime)
@@ -60,7 +61,8 @@ defmodule Grapevine.Games.Game do
       :description,
       :display,
       :allow_character_registration,
-      :enable_web_client
+      :enable_web_client,
+      :allow_anonymous_client
     ])
     |> validate_required([
       :name,
@@ -69,7 +71,8 @@ defmodule Grapevine.Games.Game do
       :user_id,
       :display,
       :allow_character_registration,
-      :enable_web_client
+      :enable_web_client,
+      :allow_anonymous_client
     ])
     |> check_name_against_block_list(:name)
     |> check_name_against_block_list(:short_name)

--- a/lib/grapevine/telnet/web_client.ex
+++ b/lib/grapevine/telnet/web_client.ex
@@ -18,10 +18,10 @@ defmodule Grapevine.Telnet.WebClient do
     send(pid, {:recv, message})
   end
 
-  def connect(user, opts) do
-    case :global.whereis_name(pid(user, opts)) do
+  def connect(session_token, opts) do
+    case :global.whereis_name(pid(session_token, opts)) do
       :undefined ->
-        ClientSupervisor.start_client(__MODULE__, opts ++ [name: {:global, pid(user, opts)}])
+        ClientSupervisor.start_client(__MODULE__, opts ++ [name: {:global, pid(session_token, opts)}])
 
       pid ->
         set_channel(pid, opts[:channel_pid])
@@ -29,8 +29,8 @@ defmodule Grapevine.Telnet.WebClient do
     end
   end
 
-  defp pid(user, opts) do
-    {:webclient, {user.id, Keyword.fetch!(opts, :game_id)}}
+  defp pid(session_token, opts) do
+    {:webclient, {session_token, Keyword.fetch!(opts, :game_id)}}
   end
 
   defp set_channel(pid, channel_pid) do

--- a/lib/web/channels/play_channel.ex
+++ b/lib/web/channels/play_channel.ex
@@ -7,6 +7,7 @@ defmodule Web.PlayChannel do
 
   alias Grapevine.Games
   alias Grapevine.Telnet.WebClient
+  alias Web.Game
 
   def join("play:client", message, socket) do
     case Map.has_key?(socket.assigns, :session_token) do
@@ -33,18 +34,12 @@ defmodule Web.PlayChannel do
   end
 
   defp check_user_allowed(socket, game) do
-    case game.allow_anonymous_client do
+    case Game.client_allowed?(game, socket.assigns) do
       true ->
         {:ok, game}
 
       false ->
-        case Map.has_key?(socket.assigns, :user) && socket.assigns.user != nil do
-          true ->
-            {:ok, game}
-
-          false ->
-            :error
-        end
+        :error
     end
   end
 

--- a/lib/web/channels/play_channel.ex
+++ b/lib/web/channels/play_channel.ex
@@ -9,7 +9,7 @@ defmodule Web.PlayChannel do
   alias Grapevine.Telnet.WebClient
 
   def join("play:client", message, socket) do
-    case Map.has_key?(socket.assigns, :user) do
+    case Map.has_key?(socket.assigns, :session_token) do
       true ->
         with {:ok, socket} <- assign_game(socket, message) do
           start_client(socket)
@@ -23,7 +23,8 @@ defmodule Web.PlayChannel do
   defp assign_game(socket, message) do
     with {:ok, short_name} <- Map.fetch(message, "game"),
          {:ok, game} <- Games.get_by_short(short_name),
-         {:ok, game} <- Games.check_web_client(game) do
+         {:ok, game} <- Games.check_web_client(game),
+         {:ok, game} <- check_user_allowed(socket, game) do
       {:ok, assign(socket, :game, game)}
     else
       _ ->
@@ -31,10 +32,26 @@ defmodule Web.PlayChannel do
     end
   end
 
+  defp check_user_allowed(socket, game) do
+    case game.allow_anonymous_client do
+      true ->
+        {:ok, game}
+
+      false ->
+        case Map.has_key?(socket.assigns, :user) && socket.assigns.user != nil do
+          true ->
+            {:ok, game}
+
+          false ->
+            :error
+        end
+    end
+  end
+
   def start_client(socket) do
     {:ok, connection} = Games.get_web_client_connection(socket.assigns.game)
 
-    {:ok, pid} = WebClient.connect(socket.assigns.user,
+    {:ok, pid} = WebClient.connect(socket.assigns.session_token,
       game_id: socket.assigns.game.id,
       host: connection.host,
       port: connection.port,

--- a/lib/web/controllers/play_controller.ex
+++ b/lib/web/controllers/play_controller.ex
@@ -5,7 +5,8 @@ defmodule Web.PlayController do
 
   def show(conn, %{"game_id" => short_name}) do
     with {:ok, game} <- Games.get_by_short(short_name, display: true),
-         {:ok, game} <- Games.check_web_client(game) do
+         {:ok, game} <- Games.check_web_client(game),
+         {:ok, game} <- check_user_allowed(conn, game) do
       conn
       |> assign(:game, game)
       |> put_layout("fullscreen.html")
@@ -15,6 +16,22 @@ defmodule Web.PlayController do
         conn
         |> put_flash(:error, "The web client is disabled for this game.")
         |> redirect(to: page_path(conn, :index))
+    end
+  end
+
+  defp check_user_allowed(conn, game) do
+    case game.allow_anonymous_client do
+      true ->
+        {:ok, game}
+
+      false ->
+        case Map.has_key?(conn.assigns, :user) && conn.assigns.user != nil do
+          true ->
+            {:ok, game}
+
+          false ->
+            {:error, :user_required}
+        end
     end
   end
 end

--- a/lib/web/controllers/play_controller.ex
+++ b/lib/web/controllers/play_controller.ex
@@ -2,6 +2,7 @@ defmodule Web.PlayController do
   use Web, :controller
 
   alias Grapevine.Games
+  alias Web.Game
 
   def show(conn, %{"game_id" => short_name}) do
     with {:ok, game} <- Games.get_by_short(short_name, display: true),
@@ -20,18 +21,12 @@ defmodule Web.PlayController do
   end
 
   defp check_user_allowed(conn, game) do
-    case game.allow_anonymous_client do
+    case Game.client_allowed?(game, conn.assigns) do
       true ->
         {:ok, game}
 
       false ->
-        case Map.has_key?(conn.assigns, :user) && conn.assigns.user != nil do
-          true ->
-            {:ok, game}
-
-          false ->
-            {:error, :user_required}
-        end
+        {:error, :not_allowed}
     end
   end
 end

--- a/lib/web/game.ex
+++ b/lib/web/game.ex
@@ -15,4 +15,19 @@ defmodule Web.Game do
     |> Enum.shuffle()
     |> List.first()
   end
+
+  @doc """
+  Check if the client is allowed to load
+
+  If anonymous users are not allowed, a user must be present
+  """
+  def client_allowed?(game, assigns) do
+    case game.allow_anonymous_client do
+      true ->
+        true
+
+      false ->
+        Map.has_key?(assigns, :user) && !is_nil(assigns.user)
+    end
+  end
 end

--- a/lib/web/plugs/session_token.ex
+++ b/lib/web/plugs/session_token.ex
@@ -1,0 +1,29 @@
+defmodule Web.Plugs.SessionToken do
+  @moduledoc """
+  Insert a session token, signed by phoenix
+
+  Session should be loaded before calling
+  """
+
+  import Plug.Conn
+
+  def init(default), do: default
+
+  def call(conn, _opts) do
+    case get_session(conn, :session_token) do
+      nil ->
+        generate_token(conn)
+
+      token ->
+        assign(conn, :session_token, token)
+    end
+  end
+
+  defp generate_token(conn) do
+    token = Phoenix.Token.sign(conn, "session token", UUID.uuid4())
+
+    conn
+    |> assign(:session_token, token)
+    |> put_session(:session_token, token)
+  end
+end

--- a/lib/web/router.ex
+++ b/lib/web/router.ex
@@ -23,6 +23,10 @@ defmodule Web.Router do
     plug Web.Plugs.EnsureUser
   end
 
+  pipeline :session_token do
+    plug Web.Plugs.SessionToken
+  end
+
   scope "/", Web do
     pipe_through(:browser)
 
@@ -63,6 +67,10 @@ defmodule Web.Router do
     pipe_through([:browser, :logged_in])
 
     resources("/chat", ChatController, only: [:index])
+  end
+
+  scope "/", Web do
+    pipe_through([:browser, :session_token])
 
     get("/games/:game_id/play", PlayController, :show)
   end

--- a/lib/web/templates/layout/fullscreen.html.eex
+++ b/lib/web/templates/layout/fullscreen.html.eex
@@ -2,7 +2,7 @@
 <html lang="en">
   <%= render("_head.html", assigns) %>
 
-  <body id="body" data-user-token="<%= @conn |> user_token() %>">
+  <body id="body" data-user-token="<%= user_token(@conn) %>" data-session-token="<%= session_token(@conn) %>">
     <%= render("_header.html", assigns) %>
 
     <%= render @view_module, @view_template, assigns %>

--- a/lib/web/templates/manage/game/_form.html.eex
+++ b/lib/web/templates/manage/game/_form.html.eex
@@ -34,6 +34,12 @@
         If enabled and a telnet or secure telnet connection exists, players will be able to use the Grapevine Web client to connect to your game.
       </div>
     <% end %>
+
+    <%= FormView.checkbox_field(f, :allow_anonymous_client, label: "Allow anonymous use of the web client?") do %>
+      <div class="help-block">
+        If enabled anyone can load the web client for your game.
+      </div>
+    <% end %>
   <% end %>
 
   <div class="row">

--- a/lib/web/templates/manage/game/show.html.eex
+++ b/lib/web/templates/manage/game/show.html.eex
@@ -52,11 +52,21 @@
 
       <div>
         <%= if @game.enable_web_client do %>
-          Players <b>can</b> use the web client.
+          Players <b>can</b> use the <%= link("web client.", to: play_path(@conn, :show, @game.short_name)) %>
         <% else %>
           Players <b>cannot</b> use the web client.
         <% end %>
       </div>
+
+      <%= if @game.enable_web_client do %>
+        <div>
+          <%= if @game.allow_anonymous_client do %>
+            <b>Any</b> player can use the web client.
+          <% else %>
+            Players <b>must be</b> registered to use the web client.
+          <% end %>
+        </div>
+      <% end %>
 
       <hr />
 

--- a/lib/web/views/layout_view.ex
+++ b/lib/web/views/layout_view.ex
@@ -4,6 +4,8 @@ defmodule Web.LayoutView do
   def user_token(%{assigns: %{user_token: token}}), do: token
   def user_token(_), do: ""
 
+  def session_token(conn), do: conn.assigns.session_token
+
   def analytics_configured?() do
     analytics_id() != nil
   end

--- a/priv/repo/migrations/20190206221158_add_enable_anonymous_web_client_to_games.exs
+++ b/priv/repo/migrations/20190206221158_add_enable_anonymous_web_client_to_games.exs
@@ -1,0 +1,9 @@
+defmodule Grapevine.Repo.Migrations.AddEnableAnonymousWebClientToGames do
+  use Ecto.Migration
+
+  def change do
+    alter table(:games) do
+      add(:allow_anonymous_client, :boolean, default: false, null: false)
+    end
+  end
+end

--- a/test/web/game_test.exs
+++ b/test/web/game_test.exs
@@ -1,0 +1,27 @@
+defmodule Web.GameTest do
+  use ExUnit.Case
+
+  alias Web.Game
+
+  describe "checking if the client is allowed to load" do
+    test "anonymous allowed" do
+      game = %{allow_anonymous_client: true}
+
+      assert Game.client_allowed?(game, %{})
+      assert Game.client_allowed?(game, %{user: %{}})
+    end
+
+    test "anonymous not allowed, user is assigned" do
+      game = %{allow_anonymous_client: false}
+      user = %{id: 1}
+
+      assert Game.client_allowed?(game, %{user: user})
+    end
+
+    test "anonymous not allowed, no user" do
+      game = %{allow_anonymous_client: false}
+
+      refute Game.client_allowed?(game, %{})
+    end
+  end
+end


### PR DESCRIPTION
New flag for games to enable anyone to use the web client, uses a
session token to "stick" the backing telnet client to the same browser
allowing for reloads.