### PR TITLE
Let the play page be loaded for a game by CNAME

### DIFF
--- a/.travis/test.exs
+++ b/.travis/test.exs
@@ -24,3 +24,5 @@ config :grapevine, Grapevine.Mailer, adapter: Bamboo.TestAdapter
 config :grapevine, :modules, client: Test.FakeClient
 
 config :grapevine, :storage, backend: :test
+
+config :grapevine, :web, url: [host: "www.example.com"]

--- a/README.md
+++ b/README.md
@@ -72,4 +72,13 @@ config :grapevine,
   ]
 ```
 
+## Setting up a new Play CNAME
+
+- Game must have a homepage url
+- Game must have the web client enabled
+- Update game's record for their CNAME
+- Update nginx config for new domain
+- Run certbot for the new domain
+- Refresh CNAMEs in ETS `Grapevine.CNAMEs.reload()`
+
 [websocket-docs]: https://grapevine.haus/docs

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -66,6 +66,8 @@ config :phoenix, :plug_init_mode, :runtime
 
 config :grapevine, Grapevine.Mailer, adapter: Bamboo.LocalAdapter
 
+config :grapevine, :web, host: "localhost"
+
 if File.exists?("config/dev.local.exs") do
   import_config("dev.local.exs")
 end

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -18,6 +18,8 @@ config :grapevine, Web.Endpoint,
   url: [host: "example.com", port: 80],
   cache_static_manifest: "priv/static/cache_manifest.json"
 
+config :grapevine, :web, url: [host: "grapevine.haus", scheme: "https", port: 443]
+
 # Do not print debug messages in production
 config :logger,
   level: :info,

--- a/config/test.exs
+++ b/config/test.exs
@@ -25,3 +25,5 @@ config :grapevine, Grapevine.Mailer, adapter: Bamboo.TestAdapter
 config :grapevine, :modules, client: Test.FakeClient
 
 config :grapevine, :storage, backend: :test
+
+config :grapevine, :web, url: [host: "www.example.com"]

--- a/lib/grapevine/application.ex
+++ b/lib/grapevine/application.ex
@@ -18,7 +18,8 @@ defmodule Grapevine.Application do
       {Grapevine.Client.Server, [name: Grapevine.Client.Server]},
       {Metrics.Server, []},
       {Telemetry.Poller, telemetry_opts()},
-      {Grapevine.Telnet.Worker, [name: Grapevine.Telnet.Worker]}
+      {Grapevine.Telnet.Worker, [name: Grapevine.Telnet.Worker]},
+      {Grapevine.CNAMEs, [name: Grapevine.CNAMEs]}
     ]
 
     Metrics.Setup.setup()

--- a/lib/grapevine/cnames.ex
+++ b/lib/grapevine/cnames.ex
@@ -1,0 +1,55 @@
+defmodule Grapevine.CNAMEs do
+  @moduledoc """
+  Sets up and handles reloads for any CNAMEs for the app
+  """
+
+  use GenServer
+
+  alias Grapevine.Games
+
+  @ets_key :cnames
+
+  @doc false
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, [], opts)
+  end
+
+  def reload() do
+    GenServer.call(__MODULE__, {:reload})
+  end
+
+  @doc """
+  Check if the hostname is known
+  """
+  def host_known?(host) do
+    case :ets.lookup(@ets_key, host) do
+      [{^host, _}] ->
+        true
+
+      _ ->
+        false
+    end
+  end
+
+  def init(_) do
+    create_table()
+    {:ok, %{}}
+  end
+
+  def handle_continue(:setup_ets, state) do
+    Enum.each(Games.with_cname(), fn game ->
+      :ets.insert(@ets_key, {game.cname, game.id})
+    end)
+
+    {:noreply, state}
+  end
+
+  def handle_call({:reload}, _from, state) do
+    {:noreply, state} = handle_continue(:setup_ets, state)
+    {:reply, :ok, state}
+  end
+
+  defp create_table() do
+    :ets.new(@ets_key, [:set, :protected, :named_table])
+  end
+end

--- a/lib/grapevine/games.ex
+++ b/lib/grapevine/games.ex
@@ -96,6 +96,15 @@ defmodule Grapevine.Games do
   end
 
   @doc """
+  Load all games with a cname
+  """
+  def with_cname() do
+    Game
+    |> where([g], not is_nil(g.cname))
+    |> Repo.all()
+  end
+
+  @doc """
   Fetch a game
   """
   @spec get(id()) :: Game.t()
@@ -132,7 +141,7 @@ defmodule Grapevine.Games do
         {:error, :not_found}
 
       game ->
-        {:ok, Repo.preload(game, [:connections, :redirect_uris])}
+        {:ok, Repo.preload(game, [:connections, :gauges, :redirect_uris])}
     end
   end
 
@@ -147,6 +156,15 @@ defmodule Grapevine.Games do
       game ->
         {:ok, Repo.preload(game, [:connections, :gauges, :redirect_uris])}
     end
+  end
+
+  @doc """
+  Get a game by it's CNAME
+
+  This value must be set from the database
+  """
+  def get_by_host(host) do
+    get_by(cname: host, display: true)
   end
 
   @doc """

--- a/lib/grapevine/games/game.ex
+++ b/lib/grapevine/games/game.ex
@@ -40,6 +40,8 @@ defmodule Grapevine.Games.Game do
     field(:cover_key, Ecto.UUID)
     field(:cover_extension, :string)
 
+    field(:cname, :string)
+
     belongs_to(:user, User)
 
     has_many(:achievements, Achievement)

--- a/lib/web.ex
+++ b/lib/web.ex
@@ -23,6 +23,8 @@ defmodule Web do
       import Plug.Conn
       import Web.Router.Helpers
       import Web.Gettext
+
+      alias Web.Router.Helpers, as: Routes
     end
   end
 

--- a/lib/web/controllers/page_controller.ex
+++ b/lib/web/controllers/page_controller.ex
@@ -1,14 +1,31 @@
 defmodule Web.PageController do
   use Web, :controller
 
+  alias Grapevine.CNAMEs
   alias Grapevine.Games
 
-  def index(conn, _params) do
-    games = Games.public(filter: %{"online" => "yes", "cover" => "yes"})
+  action_fallback(Web.FallbackController)
 
-    conn
-    |> assign(:games, games)
-    |> render("index.html")
+  @config Application.get_env(:grapevine, :web)
+
+  def index(conn, _params) do
+    case conn.host != @config[:host] do
+      true ->
+        case CNAMEs.host_known?(conn.host) do
+          true ->
+            redirect(conn, to: Routes.play_path(conn, :client))
+
+          false ->
+            {:error, :not_found}
+        end
+
+      false ->
+        games = Games.public(filter: %{"online" => "yes", "cover" => "yes"})
+
+        conn
+        |> assign(:games, games)
+        |> render("index.html")
+    end
   end
 
   def conduct(conn, _params) do

--- a/lib/web/controllers/play_controller.ex
+++ b/lib/web/controllers/play_controller.ex
@@ -29,6 +29,24 @@ defmodule Web.PlayController do
     end
   end
 
+  def client(conn, _params) do
+    with {:ok, game} <- Games.get_by_host(conn.host),
+         {:ok, game} <- Games.check_web_client(game),
+         {:ok, game} <- check_user_allowed(conn, game) do
+      conn
+      |> assign(:game, game)
+      |> assign(:title, "Play #{game.name}")
+      |> assign(:open_graph_title, game.name)
+      |> assign(:open_graph_description, "Play #{game.name} on Grapevine")
+      |> assign(:open_graph_url, play_url(conn, :show, game.short_name))
+      |> put_layout("cname.html")
+      |> render("show.html")
+    else
+      {:error, _} ->
+        {:error, :not_found}
+    end
+  end
+
   defp check_user_allowed(conn, game) do
     case Game.client_allowed?(game, conn.assigns, :current_user) do
       true ->

--- a/lib/web/plugs/validate_host.ex
+++ b/lib/web/plugs/validate_host.ex
@@ -1,0 +1,26 @@
+defmodule Web.Plugs.ValidateHost do
+  @moduledoc """
+  Validate the host matches the configured grapevine host
+  """
+
+  @config Application.get_env(:grapevine, :web)[:url]
+
+  import Plug.Conn
+  import Phoenix.Controller
+
+  alias Web.Router.Helpers, as: Routes
+
+  def init(default), do: default
+
+  def call(conn, _opts) do
+    case conn.host == @config[:host] do
+      true ->
+        conn
+
+      false ->
+        conn
+        |> redirect(to: Routes.page_path(conn, :index))
+        |> halt()
+    end
+  end
+end

--- a/lib/web/router.ex
+++ b/lib/web/router.ex
@@ -8,6 +8,7 @@ defmodule Web.Router do
     plug(:protect_from_forgery)
     plug(:put_secure_browser_headers)
     plug(Web.Plugs.FetchUser)
+    plug(Web.Plugs.ValidateHost)
   end
 
   pipeline :api do
@@ -27,10 +28,29 @@ defmodule Web.Router do
     plug Web.Plugs.SessionToken
   end
 
+  pipeline :cname do
+    plug(:accepts, ["html", "json"])
+    plug(:fetch_session)
+    plug(:fetch_flash)
+    plug(:protect_from_forgery)
+    plug(:put_secure_browser_headers)
+    plug(Web.Plugs.FetchUser)
+  end
+
   scope "/", Web do
-    pipe_through(:browser)
+    pipe_through([:cname])
 
     get("/", PageController, :index)
+  end
+
+  scope "/", Web do
+    pipe_through([:cname, :session_token])
+
+    get("/client", PlayController, :client)
+  end
+
+  scope "/", Web do
+    pipe_through([:browser])
 
     get("/conduct", PageController, :conduct)
 

--- a/lib/web/templates/layout/cname.html.eex
+++ b/lib/web/templates/layout/cname.html.eex
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+  <%= render("_head.html", assigns) %>
+
+  <body id="body" data-user-token="<%= user_token(@conn) %>" data-session-token="<%= session_token(@conn) %>">
+    <header>
+      <nav class="navbar navbar-expand-md">
+        <div class="container">
+          <%= link(to: grapevine_url(), class: "navbar-brand", target: "_blank") do %>
+            <%= img_tag("/images/grapevine.png", height: 30) %>
+          <% end %>
+
+          <div class="collapse navbar-collapse" id="navbarLinks">
+            <ul class="navbar-nav ml-auto">
+              <li class="nav-item">
+                <%= link(to: @game.homepage_url, class: "nav-link", target: "_blank") do %>
+                  <%= @game.name %> &raquo;
+                <% end %>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </nav>
+    </header>
+
+    <%= render @view_module, @view_template, assigns %>
+
+    <script src="<%= static_path(@conn, "/js/app.js") %>"></script>
+
+    <%= render("_analytics.html", assigns) %>
+  </body>
+</html>

--- a/lib/web/views/layout_view.ex
+++ b/lib/web/views/layout_view.ex
@@ -1,6 +1,8 @@
 defmodule Web.LayoutView do
   use Web, :view
 
+  @config Application.get_env(:grapevine, :web)[:url]
+
   def user_token(%{assigns: %{user_token: token}}), do: token
   def user_token(_), do: ""
 
@@ -12,5 +14,10 @@ defmodule Web.LayoutView do
 
   def analytics_id() do
     Application.get_env(:grapevine, :web)[:analytics_id]
+  end
+
+  def grapevine_url() do
+    uri = %URI{scheme: @config[:scheme], host: @config[:host], port: @config[:port]}
+    Routes.page_url(uri, :index)
   end
 end

--- a/priv/repo/migrations/20190223010505_add_cname_to_games.exs
+++ b/priv/repo/migrations/20190223010505_add_cname_to_games.exs
@@ -1,0 +1,11 @@
+defmodule Grapevine.Repo.Migrations.AddCnameToGames do
+  use Ecto.Migration
+
+  def change do
+    alter table(:games) do
+      add(:cname, :string)
+    end
+
+    create index(:games, :cname, unique: true)
+  end
+end


### PR DESCRIPTION
- [x] lock down other domains to `/` and `/client` only
- [x] skips any kind of sign in
- [x] header displays the game name with grapevine branding
- [x] check for domain is in ETS and loaded on app boot, refreshable via a message