### PR TITLE
Add view count to events

### DIFF
--- a/apps/data/lib/grapevine_data/events.ex
+++ b/apps/data/lib/grapevine_data/events.ex
@@ -34,6 +34,15 @@ defmodule GrapevineData.Events do
   end
 
   @doc """
+  Increment view count for event
+  """
+  def inc_view_count(event) do
+    event
+    |> Event.inc_view_count_changeset(%{view_count: 1 + event.view_count})
+    |> Repo.update()
+  end
+
+  @doc """
   Get all events for a game
   """
   def for(game) do

--- a/apps/data/lib/grapevine_data/events/event.ex
+++ b/apps/data/lib/grapevine_data/events/event.ex
@@ -17,6 +17,7 @@ defmodule GrapevineData.Events.Event do
     field(:description, :string)
     field(:start_date, :date)
     field(:end_date, :date)
+    field(:view_count, :integer, default: 0)
 
     belongs_to(:game, Game)
 
@@ -28,6 +29,11 @@ defmodule GrapevineData.Events.Event do
     |> cast(params, [:title, :description, :start_date, :end_date])
     |> validate_required([:title, :description, :start_date, :end_date])
     |> validate_start_before_end()
+  end
+
+  def inc_view_count_changeset(struct, params) do
+    struct
+    |> cast(params, [:view_count])
   end
 
   defp validate_start_before_end(changeset) do

--- a/apps/data/lib/grapevine_data/events/event.ex
+++ b/apps/data/lib/grapevine_data/events/event.ex
@@ -26,7 +26,7 @@ defmodule GrapevineData.Events.Event do
   def changeset(struct, params) do
     struct
     |> cast(params, [:title, :description, :start_date, :end_date])
-    |> validate_required([:title, :start_date, :end_date])
+    |> validate_required([:title, :description, :start_date, :end_date])
     |> validate_start_before_end()
   end
 

--- a/apps/data/priv/repo/migrations/20191004151514_update_games_table.exs
+++ b/apps/data/priv/repo/migrations/20191004151514_update_games_table.exs
@@ -1,0 +1,17 @@
+defmodule GrapevineData.Repo.Migrations.UpdateGamesTable do
+  use Ecto.Migration
+
+  def up do
+    execute "UPDATE games SET description = '' WHERE description IS NULL"
+    alter table(:games) do
+      modify :description, :text, null: false
+    end
+  end
+
+  def down do
+    alter table(:games) do
+      modify :description, :text, null: true
+    end
+    execute "UPDATE games SET description = NULL WHERE description = ''"
+  end
+end

--- a/apps/data/priv/repo/migrations/20191004152624_add_event_view_count_to_events.exs
+++ b/apps/data/priv/repo/migrations/20191004152624_add_event_view_count_to_events.exs
@@ -1,0 +1,9 @@
+defmodule GrapevineData.Repo.Migrations.AddEventViewCountToEvents do
+  use Ecto.Migration
+
+  def change do
+    alter table(:events) do
+      add :view_count, :integer, default: 0, null: false
+    end
+  end
+end

--- a/lib/web/controllers/event_controller.ex
+++ b/lib/web/controllers/event_controller.ex
@@ -16,7 +16,8 @@ defmodule Web.EventController do
   end
 
   def show(conn, %{"id" => id}) do
-    with {:ok, event} <- Events.get_uid(id) do
+    with {:ok, event} <- Events.get_uid(id),
+         {:ok, _} <- Events.inc_view_count(event) do
       conn
       |> assign(:event, event)
       |> assign(:game, event.game)

--- a/lib/web/templates/admin/event/index.html.eex
+++ b/lib/web/templates/admin/event/index.html.eex
@@ -26,6 +26,7 @@
             <th>Title</th>
             <th>Start Date</th>
             <th>End End Date</th>
+            <th>View count</th>
             <th>Actions</th>
           </tr>
         </thead>
@@ -42,6 +43,7 @@
               <td><%= event.title %></td>
               <td><%= event.start_date %></td>
               <td><%= event.end_date %></td>
+              <td><%= event.view_count %></td>
               <td>
                 <%= link("View", to: Routes.admin_event_path(@conn, :show, event.uid), class: "btn btn-flat") %>
                 <%= link("Edit", to: Routes.admin_event_path(@conn, :edit, event.uid), class: "btn btn-flat") %>

--- a/lib/web/templates/admin/event/show.html.eex
+++ b/lib/web/templates/admin/event/show.html.eex
@@ -42,6 +42,10 @@
             <td><%= @event.title %></td>
           </tr>
           <tr>
+            <th>View count</th>
+            <td><%= @event.view_count %></td>
+          </tr>
+          <tr>
             <th>Description</th>
             <td><%= MarkdownView.parse(@event.description) %></td>
           </tr>

--- a/test/grapevine/events_test.exs
+++ b/test/grapevine/events_test.exs
@@ -10,11 +10,13 @@ defmodule GrapevineData.EventsTest do
       {:ok, event} =
         Events.create(game, %{
           title: "Adventuring",
+          description: "Example description.",
           start_date: "2018-11-21",
           end_date: "2018-11-23"
         })
 
       assert event.title == "Adventuring"
+      assert event.description == "Example description."
       assert event.start_date == ~D[2018-11-21]
       assert event.end_date == ~D[2018-11-23]
     end
@@ -25,6 +27,7 @@ defmodule GrapevineData.EventsTest do
       {:error, _changeset} =
         Events.create(game, %{
           title: "Adventuring",
+          description: "Example description.",
           start_date: "2018-11-21",
           end_date: "2018-11-20"
         })
@@ -38,6 +41,7 @@ defmodule GrapevineData.EventsTest do
       {:ok, event} =
         Events.create(game, %{
           title: "Adventuring",
+          description: "Example description.",
           start_date: "2018-11-21",
           end_date: "2018-11-23"
         })
@@ -58,6 +62,7 @@ defmodule GrapevineData.EventsTest do
       {:ok, event} =
         Events.create(game, %{
           title: "Adventuring",
+          description: "Example description.",
           start_date: "2018-11-21",
           end_date: "2018-11-23"
         })

--- a/test/grapevine/events_test.exs
+++ b/test/grapevine/events_test.exs
@@ -70,4 +70,22 @@ defmodule GrapevineData.EventsTest do
       {:ok, _event} = Events.delete(event)
     end
   end
+
+  describe "incrementing the view count of an event" do
+    test "successful" do
+      game = create_game(create_user())
+
+      {:ok, event} =
+        Events.create(game, %{
+          title: "Adventuring",
+          description: "Example description.",
+          start_date: "2018-11-21",
+          end_date: "2018-11-23"
+        })
+
+      {:ok, event} = Events.inc_view_count(event)
+
+      assert event.view_count == 1
+    end
+  end
 end


### PR DESCRIPTION
Fixes #102.

Two questions:

1. Currently, if the event has no description, the show page raises `no function clause matching in Earmark.Parser.parse_markdown/2` since `nil` does not match the guard in the function clause (which expects a list or binary). We could either require a description, as I do in the first commit of this PR, or where description is `nil` pass the parser an empty string. What do you think?

2. Where should counts be stored?